### PR TITLE
Memoize handlers with useCallback and fix effect dependencies in pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import "./App.css";
 import styled from "styled-components";
 import { BrowserRouter, Routes, Route, useLocation } from "react-router-dom";
@@ -107,14 +107,17 @@ function App() {
       };
       fetchUserInfo();
     }
-  }, [isLoggedIn]);
+  }, []);
 
-  const updateUserState = (token?: string, nick?: string, img?: string) => {
-    if (token) localStorage.setItem("accessToken", token);
-    setIsLoggedIn(true);
-    setNickname(nick || "사용자");
-    setProfileImg(img || "");
-  };
+  const updateUserState = useCallback(
+    (token?: string, nick?: string, img?: string) => {
+      if (token) localStorage.setItem("accessToken", token);
+      setIsLoggedIn(true);
+      setNickname(nick || "사용자");
+      setProfileImg(img || "");
+    },
+    []
+  );
 
   const handleLogout = async () => {
     try {
@@ -124,7 +127,7 @@ function App() {
     } finally {
       localStorage.removeItem("accessToken");
       setIsLoggedIn(false);
-    setNickname("사용자");
+      setNickname("사용자");
       setProfileImg("");
     }
   };
@@ -173,5 +176,4 @@ function App() {
 }
 
 export default App;
-
 

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import styled from "styled-components";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import FilterSidebar from "../components/main/FilterSidebar";
@@ -94,9 +94,31 @@ const MainPage: React.FC = () => {
   const { nameKR, Icon } = currentCountryInfo;
 
   // 이색 관광지 api 연동
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const fetchPlaces = (lat: number, lng: number) => {
-    return getPlaces(
+  const fetchPlaces = useCallback(
+    (lat: number, lng: number) => {
+      return getPlaces(
+        currentPage,
+        cardsPerPage,
+        filters.areaCode,
+        filters.contentType,
+        filters.season,
+        filters.countryRegion,
+        filters.sortType,
+        lat,
+        lng,
+        searchKeyword
+      )
+        .then((res) => {
+          if (res?.data?.content) {
+            setPlaces(res.data.content);
+            setTotalPages(res.data.totalPage);
+          }
+        })
+        .catch((error) => {
+          console.error("장소 가져오기 실패", error);
+        });
+    },
+    [
       currentPage,
       cardsPerPage,
       filters.areaCode,
@@ -104,20 +126,9 @@ const MainPage: React.FC = () => {
       filters.season,
       filters.countryRegion,
       filters.sortType,
-      lat,
-      lng,
-      searchKeyword
-    )
-      .then((res) => {
-        if (res?.data?.content) {
-          setPlaces(res.data.content);
-          setTotalPages(res.data.totalPage);
-        }
-      })
-      .catch((error) => {
-        console.error("장소 가져오기 실패", error);
-      });
-  };
+      searchKeyword,
+    ]
+  );
 
   // 위치 기반으로 호출
   useEffect(() => {
@@ -133,7 +144,7 @@ const MainPage: React.FC = () => {
         fetchPlaces(37.5665, 126.978).finally(() => setLoading(false)); // API 완료 후 로딩 종료
       }
     );
-  }, [currentPage, fetchPlaces, filters, searchTrigger]);
+  }, [fetchPlaces, searchTrigger]);
 
 
   const sortOptions = [

--- a/src/pages/PlaceDetail.tsx
+++ b/src/pages/PlaceDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect } from "react";
+import React, { useRef, useState, useEffect, useCallback } from "react";
 import styled from "styled-components";
 import { useLocation } from "react-router-dom";
 import { ReactComponent as AirPlane } from "../assets/main/Airplane.svg";
@@ -322,8 +322,7 @@ const PlaceDetail: React.FC = () => {
   };
 
   // 리뷰 불러오기
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const fetchReviews = async () => {
+  const fetchReviews = useCallback(async () => {
     if (!placeDetail?.id) return;
 
     setReviewsLoading(true);
@@ -336,12 +335,14 @@ const PlaceDetail: React.FC = () => {
     } finally {
       setReviewsLoading(false);
     }
-  };
+  }, [placeDetail?.id, reviewSortType]);
 
   // placeDetail이 바뀔 때 리뷰 호출
   useEffect(() => {
-    if (!loading && placeDetail) fetchReviews();
-  }, [placeDetail, loading, reviewSortType, fetchReviews]);
+    if (!loading && placeDetail) {
+      fetchReviews();
+    }
+  }, [loading, placeDetail, fetchReviews]);
 
   // 비행기 평균별점 계산
   const renderStars = (score: number) => {


### PR DESCRIPTION
### Motivation
- Reduce unnecessary re-renders and address stale closure / dependency issues by memoizing handler functions with `useCallback` and cleaning up `useEffect` dependencies. 
- Ensure stable callback identity for login flow so child components receive a consistent `onLogin` handler. 
- Improve robustness of place and review fetching with clearer promise handling and error logging.

### Description
- In `App.tsx` imported `useCallback`, wrapped `updateUserState` in `useCallback`, and removed `isLoggedIn` from the initial user info `useEffect` dependency. 
- In `MainPage.tsx` imported `useCallback`, converted `fetchPlaces` to a `useCallback`-memoized function that calls `getPlaces` and handles `setPlaces`/`setTotalPages` and errors, and adjusted the location-based `useEffect` to depend on `fetchPlaces` and `searchTrigger`. 
- In `PlaceDetail.tsx` imported `useCallback`, memoized `fetchReviews` with `useCallback`, and updated the `useEffect` that triggers reviews to call the memoized `fetchReviews` when `loading` and `placeDetail` change. 
- Minor formatting/whitespace fixes accompanying the changes.

### Testing
- Type checking and build (`npm run build`) completed successfully. 
- Linting (`npm run lint`) passed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7e391d140832280cbc553271f3fe7)